### PR TITLE
With sort/default sort

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-redux-composeable-list",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Composeable List in React and Redux",
   "main": "dist/bundle.js",
   "peerDependencies": {

--- a/src/helper/util/empty.js
+++ b/src/helper/util/empty.js
@@ -1,0 +1,5 @@
+const isEmpty = (obj) => Object.keys(obj).length === 0;
+
+export {
+  isEmpty
+};

--- a/src/helper/util/empty.spec.js
+++ b/src/helper/util/empty.spec.js
@@ -1,0 +1,13 @@
+import { isEmpty } from './empty';
+
+describe('empty', () => {
+  it('return true when object is empty', () => {
+    const r = isEmpty({});
+    expect(r).to.be.true;
+  });
+
+  it('return false when object is not empty', () => {
+    const r = isEmpty({ a: 1 });
+    expect(r).to.be.false;
+  });
+});


### PR DESCRIPTION
- [x] withSort needs configuration object that can be left empty
- [x] with configuration object, such as `withSort({ sortKey, sortFn })`, a default sort on component mount can be set
- [x] improvement: if there is already a sort set in the Redux store, that sort will be used instead of the configuration