### PR TITLE
Feat: Multi-select rows via shift-click

### DIFF
--- a/src/components/Row/container.js
+++ b/src/components/Row/container.js
@@ -6,6 +6,7 @@ import { getContext } from '../../helper/util/getContext';
 import { actionCreators, selectors } from '../../ducks';
 import RowSelectable from './presenter';
 import { select } from '../../helper/services';
+import { noop } from '../../helper/util/noop';
 
 const isSelectableRow = (isSelectable, id) =>
   isSelectable && !(id === undefined || id === null);
@@ -34,17 +35,21 @@ const mapStateToProps = (
   };
 }
 
-const mapDispatchToProps = (dispatch, { stateKey, isSelectable, id }) => ({
-  onSelect: isSelectableRow(isSelectable, id)
-    ? bindActionCreators(() => actionCreators.doSelectItem(stateKey, id), dispatch)
-    : () => {}
-});
+const mapDispatchToProps = (dispatch, { stateKey, isSelectable, id, allIds }) =>
+  isSelectableRow(isSelectable, id) ? ({
+    onSelect: bindActionCreators(({ event }) => actionCreators.doSelectItem(stateKey, id, allIds, event), dispatch),
+    onSelectItems: bindActionCreators((ids) => actionCreators.doSelectItems(stateKey, ids, true), dispatch),
+  }) : ({
+    onSelect: noop,
+    onSelectItems: noop,
+  });
 
 const contextTypes = {
   stateKey: PropTypes.string.isRequired,
   isSelectable: PropTypes.bool,
   preselected: PropTypes.array,
   unselectables: PropTypes.array,
+  allIds: PropTypes.array,
 };
 
 export default getContext(contextTypes)(connect(mapStateToProps, mapDispatchToProps)(RowSelectable));

--- a/src/components/Row/container.js
+++ b/src/components/Row/container.js
@@ -37,10 +37,12 @@ const mapStateToProps = (
 
 const mapDispatchToProps = (dispatch, { stateKey, isSelectable, id, allIds }) =>
   isSelectableRow(isSelectable, id) ? ({
-    onSelect: bindActionCreators(({ event }) => actionCreators.doSelectItem(stateKey, id, allIds, event), dispatch),
+    onSelect: bindActionCreators(() => actionCreators.doSelectItem(stateKey, id), dispatch),
+    onShiftSelect: bindActionCreators(() => actionCreators.doSelectItemsRange(stateKey, id, allIds), dispatch),
     onSelectItems: bindActionCreators((ids) => actionCreators.doSelectItems(stateKey, ids, true), dispatch),
   }) : ({
     onSelect: noop,
+    onShiftSelect: noop,
     onSelectItems: noop,
   });
 

--- a/src/components/Row/presenter.js
+++ b/src/components/Row/presenter.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { select } from '../../helper/services';
+import { noop } from '../../helper/util/noop';
 
 import './style.less';
 
@@ -33,15 +34,16 @@ const RowSelectable = ({
   children
 }) => {
   const rowClass = ['react-redux-composable-list-row', CLASS_MAPPING[selectState]];
+  const hasSelectState = selectState === select.SELECT_STATES.selected ||
+    selectState === select.SELECT_STATES.notSelected;
 
-  const onClick = selectState === select.SELECT_STATES.selected ||
-    selectState === select.SELECT_STATES.notSelected
-      ? onSelect
-      : () => {};
+  const handleClick = hasSelectState
+    ? event => onSelect({ event })
+    : noop;
 
   return (
     <div
-      onClick={onClick}
+      onClick={handleClick}
       className={rowClass.join(' ')}>
       {children}
     </div>

--- a/src/components/Row/presenter.js
+++ b/src/components/Row/presenter.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { select } from '../../helper/services';
-import { noop } from '../../helper/util/noop';
 
 import './style.less';
 
@@ -31,16 +30,18 @@ Row.propTypes = {
 const RowSelectable = ({
   selectState,
   onSelect,
+  onShiftSelect,
   children
 }) => {
   const rowClass = ['react-redux-composable-list-row', CLASS_MAPPING[selectState]];
   const hasSelectState = selectState === select.SELECT_STATES.selected ||
     selectState === select.SELECT_STATES.notSelected;
-
-  const handleClick = hasSelectState
-    ? event => onSelect({ event })
-    : noop;
-
+  const handleClick = event => {
+    if (!hasSelectState) {
+      return;
+    }
+    return event && event.shiftKey ? onShiftSelect() : onSelect();
+  };
   return (
     <div
       onClick={handleClick}
@@ -53,6 +54,7 @@ const RowSelectable = ({
 RowSelectable.propTypes = {
   selectState: PropTypes.string,
   onSelect: PropTypes.func.isRequired,
+  onShiftSelect: PropTypes.func.isRequired,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node

--- a/src/ducks/filter/spec.js
+++ b/src/ducks/filter/spec.js
@@ -1,5 +1,5 @@
 import deepFreeze from 'deep-freeze';
-import { reducers, actionTypes, actionCreators } from '../filter';
+import { reducers, actionCreators } from '../filter';
 
 const STATE_KEY = 'SOME_KEY';
 

--- a/src/ducks/magic/spec.js
+++ b/src/ducks/magic/spec.js
@@ -1,5 +1,5 @@
 import deepFreeze from 'deep-freeze';
-import { reducers, actionTypes, actionCreators } from '../magic';
+import { reducers, actionCreators } from '../magic';
 
 const STATE_KEY = 'SOME_KEY';
 

--- a/src/ducks/paginate/spec.js
+++ b/src/ducks/paginate/spec.js
@@ -1,5 +1,5 @@
 import deepFreeze from 'deep-freeze';
-import { reducers, actionTypes, actionCreators } from '../paginate';
+import { reducers, actionCreators } from '../paginate';
 
 const STATE_KEY = 'SOME_KEY';
 

--- a/src/ducks/select/index.js
+++ b/src/ducks/select/index.js
@@ -93,7 +93,7 @@ function applyToggleItem(state, action) {
     ? removeItem(currentSelection, index)
     : addItem(currentSelection, id);
   const lastSelectedItem = isAlreadySelected
-    ? state[stateKey].lastSelectedItem
+    ? null
     : id;
   return { ...state, [stateKey]: { selectedItems, lastSelectedItem } };
 }

--- a/src/ducks/select/index.js
+++ b/src/ducks/select/index.js
@@ -97,8 +97,7 @@ function getSelectedRange(allIds, id, lastSelectedItem) {
   const currentSelectedItemIndex = allIds.indexOf(id);
   const firstIndex = Math.min(lastSelectedItemIndex, currentSelectedItemIndex);
   const lastIndex = Math.max(lastSelectedItemIndex, currentSelectedItemIndex);
-  const selectedRange = allIds.slice(firstIndex, lastIndex + 1);
-  return selectedRange;
+  return allIds.slice(firstIndex, lastIndex + 1);
 }
 
 function applyToggleItems(state, action) {

--- a/src/ducks/select/index.js
+++ b/src/ducks/select/index.js
@@ -77,7 +77,7 @@ function applyToggleItem(state, action) {
     [];
   const index = currentSelection.indexOf(id);
   const isAlreadySelected = index !== -1;
-  if (!isAlreadySelected && event && event.shiftKey) {
+  if (!isAlreadySelected && allIds && allIds.length && event && event.shiftKey) {
     const lastSelectedItem = state[stateKey].lastSelectedItem;
     const selectedRange = getSelectedRange(allIds, id, lastSelectedItem);
     const selectedItems = uniq([...currentSelection, ...selectedRange]);

--- a/src/ducks/select/index.js
+++ b/src/ducks/select/index.js
@@ -71,7 +71,7 @@ const reducer = (state = INITIAL_STATE, action) => {
     case SELECT_ITEMS:
       return applyToggleItems(state, action);
     case SELECT_ITEMS_RANGE:
-      return applyToggleItemsRange(state, action);
+      return applySelectItemsRange(state, action);
     case SELECT_ITEMS_EXCLUSIVELY:
       return applyToggleItemsExclusively(state, action);
     case SELECT_ITEMS_RESET:
@@ -102,7 +102,7 @@ function applyToggleItems(state, action) {
   return toggleItems(state, action, false);
 }
 
-function applyToggleItemsRange(state, action) {
+function applySelectItemsRange(state, action) {
   const { stateKey, id, allIds } = action.payload;
   const currentSelection = state[stateKey] && state[stateKey].selectedItems
     ? state[stateKey].selectedItems

--- a/src/ducks/select/index.js
+++ b/src/ducks/select/index.js
@@ -78,7 +78,7 @@ function applyToggleItem(state, action) {
   const index = currentSelection.indexOf(id);
   const isAlreadySelected = index !== -1;
   if (!isAlreadySelected && allIds && allIds.length && event && event.shiftKey) {
-    const lastSelectedItem = state[stateKey].lastSelectedItem;
+    const lastSelectedItem = state[stateKey].lastSelectedItem || id;
     const selectedRange = getSelectedRange(allIds, id, lastSelectedItem);
     const selectedItems = uniq([...currentSelection, ...selectedRange]);
     return { ...state, [stateKey]: { selectedItems, lastSelectedItem } };

--- a/src/ducks/select/spec.js
+++ b/src/ducks/select/spec.js
@@ -42,28 +42,6 @@ describe('select', () => {
       deepFreeze(previousState);
       expect(reducers.tableSelect(previousState, action)).to.eql(expectedState);
     });
-
-    it('selects a range of items when shift-clicking a second item', () => {
-      const allIds = ['v', 'w', 'x', 'y', 'z'];
-      const clickEvent = { shiftKey: true };
-      const previousState = { [STATE_KEY]: { selectedItems: ['w'], lastSelectedItem: 'w' } };
-      const expectedState = { [STATE_KEY]: { selectedItems: ['w', 'x', 'y'], lastSelectedItem: 'w' } };
-      const action = actionCreators.doSelectItem(STATE_KEY, 'y', allIds, clickEvent);
-      deepFreeze(action);
-      deepFreeze(previousState);
-      expect(reducers.tableSelect(previousState, action)).to.eql(expectedState);
-    });
-
-    it('selects a single item when shift-clicking a single item without a previously-selected item', () => {
-      const allIds = ['v', 'w', 'x', 'y', 'z'];
-      const clickEvent = { shiftKey: true };
-      const previousState = { [STATE_KEY]: { selectedItems: [], lastSelectedItem: null } };
-      const expectedState = { [STATE_KEY]: { selectedItems: ['w'], lastSelectedItem: 'w' } };
-      const action = actionCreators.doSelectItem(STATE_KEY, 'w', allIds, clickEvent);
-      deepFreeze(action);
-      deepFreeze(previousState);
-      expect(reducers.tableSelect(previousState, action)).to.eql(expectedState);
-    });
   });
 
   describe('SELECT_ITEMS', () => {
@@ -92,6 +70,38 @@ describe('select', () => {
       const previousState = { [STATE_KEY]: { selectedItems: ids, lastSelectedItem: 'y' } };
       const expectedState = { [STATE_KEY]: { selectedItems: [], lastSelectedItem: null } };
       const action = actionCreators.doSelectItems(STATE_KEY, ids, false);
+      deepFreeze(action);
+      deepFreeze(previousState);
+      expect(reducers.tableSelect(previousState, action)).to.eql(expectedState);
+    });
+  });
+
+  describe('SELECT_ITEMS_RANGE', () => {
+    it('selects a range of items when shift-clicking a second item', () => {
+      const allIds = ['v', 'w', 'x', 'y', 'z'];
+      const previousState = { [STATE_KEY]: { selectedItems: ['w'], lastSelectedItem: 'w' } };
+      const expectedState = { [STATE_KEY]: { selectedItems: ['w', 'x', 'y'], lastSelectedItem: 'w' } };
+      const action = actionCreators.doSelectItemsRange(STATE_KEY, 'y', allIds);
+      deepFreeze(action);
+      deepFreeze(previousState);
+      expect(reducers.tableSelect(previousState, action)).to.eql(expectedState);
+    });
+
+    it('selects a single item when shift-clicking a single item without a previously-selected item', () => {
+      const allIds = ['v', 'w', 'x', 'y', 'z'];
+      const previousState = { [STATE_KEY]: { selectedItems: [], lastSelectedItem: null } };
+      const expectedState = { [STATE_KEY]: { selectedItems: ['w'], lastSelectedItem: 'w' } };
+      const action = actionCreators.doSelectItemsRange(STATE_KEY, 'w', allIds);
+      deepFreeze(action);
+      deepFreeze(previousState);
+      expect(reducers.tableSelect(previousState, action)).to.eql(expectedState);
+    });
+
+    it('unselects a single item when shift-clicking an already-selected item', () => {
+      const allIds = ['v', 'w', 'x', 'y', 'z'];
+      const previousState = { [STATE_KEY]: { selectedItems: ['w'], lastSelectedItem: 'w' } };
+      const expectedState = { [STATE_KEY]: { selectedItems: [], lastSelectedItem: 'w' } };
+      const action = actionCreators.doSelectItemsRange(STATE_KEY, 'w', allIds);
       deepFreeze(action);
       deepFreeze(previousState);
       expect(reducers.tableSelect(previousState, action)).to.eql(expectedState);

--- a/src/ducks/select/spec.js
+++ b/src/ducks/select/spec.js
@@ -1,5 +1,5 @@
 import deepFreeze from 'deep-freeze';
-import { reducers, actionTypes, actionCreators } from '../select';
+import { reducers, actionCreators } from '../select';
 
 const STATE_KEY = 'SOME_KEY';
 

--- a/src/ducks/select/spec.js
+++ b/src/ducks/select/spec.js
@@ -8,8 +8,26 @@ describe('select', () => {
     it('toggles a single item as selected', () => {
       const id = 'x';
       const previousState = {};
-      const expectedState = { [STATE_KEY]: [id] };
+      const expectedState = { [STATE_KEY]: { selectedItems: [id], lastSelectedItem: id } };
       const action = actionCreators.doSelectItem(STATE_KEY, id);
+      deepFreeze(action);
+      deepFreeze(previousState);
+      expect(reducers.tableSelect(previousState, action)).to.eql(expectedState);
+    });
+
+    it('updates the last selected item when selecting another item', () => {
+      const previousState = { [STATE_KEY]: { selectedItems: ['x'], lastSelectedItem: 'x' } };
+      const expectedState = { [STATE_KEY]: { selectedItems: ['x', 'y'], lastSelectedItem: 'y' } };
+      const action = actionCreators.doSelectItem(STATE_KEY, 'y');
+      deepFreeze(action);
+      deepFreeze(previousState);
+      expect(reducers.tableSelect(previousState, action)).to.eql(expectedState);
+    });
+
+    it('keep the last selected item when unselecting an item', () => {
+      const previousState = { [STATE_KEY]: { selectedItems: ['x', 'y'], lastSelectedItem: 'x' } };
+      const expectedState = { [STATE_KEY]: { selectedItems: ['x'], lastSelectedItem: 'x' } };
+      const action = actionCreators.doSelectItem(STATE_KEY, 'y');
       deepFreeze(action);
       deepFreeze(previousState);
       expect(reducers.tableSelect(previousState, action)).to.eql(expectedState);
@@ -17,8 +35,8 @@ describe('select', () => {
 
     it('toggles a single item as unselected, when it was already selected', () => {
       const id = 'x';
-      const previousState = { [STATE_KEY]: [id] };
-      const expectedState = { [STATE_KEY]: [] };
+      const previousState = { [STATE_KEY]: { selectedItems: [id], lastSelectedItem: id } };
+      const expectedState = { [STATE_KEY]: { selectedItems: [], lastSelectedItem: id } };
       const action = actionCreators.doSelectItem(STATE_KEY, id);
       deepFreeze(action);
       deepFreeze(previousState);
@@ -30,7 +48,7 @@ describe('select', () => {
     it('toggles multiple items as selected', () => {
       const ids = ['x', 'y'];
       const previousState = {};
-      const expectedState = { [STATE_KEY]: ids };
+      const expectedState = { [STATE_KEY]: { selectedItems: ids, lastSelectedItem: null } };
       const action = actionCreators.doSelectItems(STATE_KEY, ids, true);
       deepFreeze(action);
       deepFreeze(previousState);
@@ -39,8 +57,8 @@ describe('select', () => {
 
     it('toggles multiple items as selected, but uniques them', () => {
       const ids = ['x', 'y'];
-      const previousState = { [STATE_KEY]: ['x'] };
-      const expectedState = { [STATE_KEY]: ids };
+      const previousState = { [STATE_KEY]: { selectedItems: ['x'], lastSelectedItem: null } };
+      const expectedState = { [STATE_KEY]: { selectedItems: ids, lastSelectedItem: null } };
       const action = actionCreators.doSelectItems(STATE_KEY, ids, true);
       deepFreeze(action);
       deepFreeze(previousState);
@@ -49,8 +67,8 @@ describe('select', () => {
 
     it('toggles multiple items as unselected', () => {
       const ids = ['x', 'y'];
-      const previousState = { [STATE_KEY]: ids };
-      const expectedState = { [STATE_KEY]: [] };
+      const previousState = { [STATE_KEY]: { selectedItems: ids, lastSelectedItem: 'y' } };
+      const expectedState = { [STATE_KEY]: { selectedItems: [], lastSelectedItem: null } };
       const action = actionCreators.doSelectItems(STATE_KEY, ids, false);
       deepFreeze(action);
       deepFreeze(previousState);
@@ -61,8 +79,8 @@ describe('select', () => {
   describe('SELECT_ITEMS_EXCLUSIVELY', () => {
     it('toggles multiple items as selected but exclusively', () => {
       const ids = ['x', 'y'];
-      const previousState = { [STATE_KEY]: ['z'] };
-      const expectedState = { [STATE_KEY]: ids };
+      const previousState = { [STATE_KEY]: { selectedItems: ['z'], lastSelectedItem: null } };
+      const expectedState = { [STATE_KEY]: { selectedItems: ids, lastSelectedItem: null } };
       const action = actionCreators.doSelectItemsExclusively(STATE_KEY, ids, true);
       deepFreeze(action);
       deepFreeze(previousState);
@@ -73,8 +91,8 @@ describe('select', () => {
   describe('SELECT_ITEMS_RESET', () => {
     it('resets all items that nothing is selected anymore', () => {
       const ids = ['x', 'y'];
-      const previousState = { [STATE_KEY]: ids };
-      const expectedState = { [STATE_KEY]: [] };
+      const previousState = { [STATE_KEY]: { selectedItems: ids, lastSelectedItem: 'x' } };
+      const expectedState = { [STATE_KEY]: { selectedItems: [], lastSelectedItem: null } };
       const action = actionCreators.doSelectItemsReset(STATE_KEY);
       deepFreeze(action);
       deepFreeze(previousState);

--- a/src/ducks/select/spec.js
+++ b/src/ducks/select/spec.js
@@ -42,6 +42,28 @@ describe('select', () => {
       deepFreeze(previousState);
       expect(reducers.tableSelect(previousState, action)).to.eql(expectedState);
     });
+
+    it('selects a range of items when shift-clicking a second item', () => {
+      const allIds = ['v', 'w', 'x', 'y', 'z'];
+      const clickEvent = { shiftKey: true };
+      const previousState = { [STATE_KEY]: { selectedItems: ['w'], lastSelectedItem: 'w' } };
+      const expectedState = { [STATE_KEY]: { selectedItems: ['w', 'x', 'y'], lastSelectedItem: 'w' } };
+      const action = actionCreators.doSelectItem(STATE_KEY, 'y', allIds, clickEvent);
+      deepFreeze(action);
+      deepFreeze(previousState);
+      expect(reducers.tableSelect(previousState, action)).to.eql(expectedState);
+    });
+
+    it('selects a single item when shift-clicking a single item without a previously-selected item', () => {
+      const allIds = ['v', 'w', 'x', 'y', 'z'];
+      const clickEvent = { shiftKey: true };
+      const previousState = { [STATE_KEY]: { selectedItems: [], lastSelectedItem: null } };
+      const expectedState = { [STATE_KEY]: { selectedItems: ['w'], lastSelectedItem: 'w' } };
+      const action = actionCreators.doSelectItem(STATE_KEY, 'w', allIds, clickEvent);
+      deepFreeze(action);
+      deepFreeze(previousState);
+      expect(reducers.tableSelect(previousState, action)).to.eql(expectedState);
+    });
   });
 
   describe('SELECT_ITEMS', () => {

--- a/src/ducks/sort/spec.js
+++ b/src/ducks/sort/spec.js
@@ -1,5 +1,5 @@
 import deepFreeze from 'deep-freeze';
-import { reducers, actionTypes, actionCreators, getEnhancedSortFn } from '../sort';
+import { reducers, actionCreators, getEnhancedSortFn } from '../sort';
 
 const STATE_KEY = 'SOME_KEY';
 


### PR DESCRIPTION
This allows for selecting multiple rows at once by pressing shift while selecting an item. The selection feature will keep track of the last selected item and expand the selection to the next item that is toggled while holding shift.

![2018-09-03 17 14 09](https://user-images.githubusercontent.com/6429568/44994335-75bfd580-af9e-11e8-94f6-93db1e03673a.gif)

That means that `allIds` now must be provided as a context prop:
```js
compose(
    enhancements.withSelectables(),
    enhancements.withFilter(),
    enhancements.withEmpty({ component: FilteredEmptyTable }),
    enhancements.withSort(),
    withContext(
        {
            preselected: PropTypes.array,
            unselectables: PropTypes.array,
            allIds: PropTypes.array, // ← new
        },
        ({ preselected, unselectables, list }) => (
		{
			preselected,
			unselectables,
			allIds: map(i => i.id, list) // ← new
		})
    )
)(UserPickerTable);
```

Alternatively, `allIds` could be provided as a configuration value in the `withSelectables()` HOC although I'm not sure if that would still work together with `withSort()` and `withFilter()`. For now the above solution seemed fitting since we're already providing `preselected` and `unselectables` in the same way.