### PR TITLE
Unify propTypes for children and remove requiredness

### DIFF
--- a/src/components/Cell/presenter.js
+++ b/src/components/Cell/presenter.js
@@ -18,7 +18,7 @@ const Cell = ({
 Cell.propTypes = {
   style: PropTypes.object,
   className: PropTypes.string,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
 };
 
 export default Cell;

--- a/src/components/CellSelected/presenter.js
+++ b/src/components/CellSelected/presenter.js
@@ -8,7 +8,7 @@ const CellSelected = ({ state, children }) =>
 
 CellSelected.propTypes = {
   state: PropTypes.string.isRequired,
-  children: PropTypes.object.isRequired
+  children: PropTypes.object.isRequired,
 };
 
 export default CellSelected;

--- a/src/components/Enhanced/presenter.js
+++ b/src/components/Enhanced/presenter.js
@@ -37,7 +37,7 @@ Enhanced.propTypes = {
   stateKey: PropTypes.string.isRequired,
   style: PropTypes.object,
   className: PropTypes.string,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
 };
 
 Enhanced.childContextTypes = {

--- a/src/components/HeaderCell/presenter.js
+++ b/src/components/HeaderCell/presenter.js
@@ -17,7 +17,7 @@ const HeaderCell = ({
 HeaderCell.propTypes = {
   style: PropTypes.object,
   className: PropTypes.string,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
 };
 
 export default HeaderCell;

--- a/src/components/Row/presenter.js
+++ b/src/components/Row/presenter.js
@@ -24,7 +24,10 @@ Row.propTypes = {
   isSelectable: PropTypes.bool,
   style: PropTypes.object,
   className: PropTypes.string,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]),
 };
 
 const RowSelectable = ({
@@ -62,7 +65,7 @@ RowSelectable.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node
-  ]).isRequired,
+  ]),
   isHeader: PropTypes.bool
 };
 
@@ -95,7 +98,10 @@ const RowNormal = ({
 RowNormal.propTypes = {
   style: PropTypes.object,
   className: PropTypes.string,
-  children: PropTypes.node.isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]),
   isHeader: PropTypes.bool
 };
 


### PR DESCRIPTION
The `children` prop for the representational components is always defined as required (via PropTypes). This PR removes this requiredness since the children are always just printed out in these components and thus should be treated as optional (e.g. for missing values in tables).