### PR TITLE
Fix: Make list accessible for screen readers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
-  parser: "babel-eslint",
+  "env": {
+    "browser": true
+  },
+  "parser": "babel-eslint",
   "plugins": [
     "react"
   ],
@@ -8,10 +11,10 @@
     "eslint:recommended",
     "plugin:react/recommended"
   ],
-  rules: {
+  "rules": {
     "import/prefer-default-export": 0,
     "react/display-name": 0,
-    "react/prop-types": 0,
+    "react/prop-types": 0
   },
   "globals": {
     "describe": true,

--- a/src/components/Cell/presenter.js
+++ b/src/components/Cell/presenter.js
@@ -11,6 +11,7 @@ const Cell = ({
   <div
     className={className || ['react-redux-composable-list-cell', 'react-redux-composable-list-cell-body'].join(' ')}
     style={style}
+    role="gridcell"
   >
     {children}
   </div>;

--- a/src/components/CellMagicHeader/presenter.js
+++ b/src/components/CellMagicHeader/presenter.js
@@ -55,15 +55,19 @@ class CellMagicHeader extends Component {
       children
     } = this.props;
     const { isColumnSelectorShown } = this.state;
+    const handleSortClick = () => onSort(primarySort.sortKey, primarySort.sortFn);
+    const toggleColumnSelector = () => this.setColumnSelectorShown(!isColumnSelectorShown);
     return (
       <div className={[
         'react-redux-composable-list-row-magic-header-custom-column',
         'react-redux-composable-list-row-magic-header'
       ].join(' ')}>
         <a
-          onClick={() => onSort(primarySort.sortKey, primarySort.sortFn)}
+          onClick={handleSortClick}
+          onKeyPress={sort.callIfActionKey(handleSortClick)}
           className={getLinkClass(primarySort.sortKey, isActive)}
           role="button"
+          tabIndex={0}
           aria-sort={sort.getAriaSort(isActive(primarySort.sortKey), isReverse)}>
           {primarySort.label}
           &nbsp;
@@ -73,10 +77,13 @@ class CellMagicHeader extends Component {
             'react-redux-composable-list-row-magic-header-column-selector-sign',
             getLinkClass(primarySort.sortKey, isActive)
           ].join(' ')}
+          onClick={toggleColumnSelector}
+          onKeyPress={sort.callIfActionKey(toggleColumnSelector)}
           aria-label="Toggle column data"
           aria-haspopup="true"
           aria-expanded={isColumnSelectorShown}
-          onClick={() => this.setColumnSelectorShown(!isColumnSelectorShown)}>
+          role="button"
+          tabIndex={0}>
           {children}
         </a>
         <ul className={[

--- a/src/components/CellMagicHeader/presenter.js
+++ b/src/components/CellMagicHeader/presenter.js
@@ -4,6 +4,7 @@ import React from 'react';
 import './style.less';
 
 import SortCaret from '../../helper/components/SortCaret';
+import { sort } from '../../helper/services';
 
 const getLinkClass = (sortKey, isActive) => {
   const linkClass = ['react-redux-composable-list-row-magic-header-inline'];
@@ -31,7 +32,9 @@ const CellMagicHeader = ({
     ].join(' ')}>
     <a
       onClick={() => onSort(primarySort.sortKey, primarySort.sortFn)}
-      className={getLinkClass(primarySort.sortKey, isActive)}>
+      className={getLinkClass(primarySort.sortKey, isActive)}
+      role="button"
+      aria-sort={sort.getAriaSort(isActive(primarySort.sortKey), isReverse)}>
       {primarySort.label}
       &nbsp;
       <SortCaret suffix={suffix} isActive={isActive(primarySort.sortKey)} isReverse={isReverse} />
@@ -39,19 +42,25 @@ const CellMagicHeader = ({
     <a className={[
         'react-redux-composable-list-row-magic-header-column-selector-sign',
         getLinkClass(primarySort.sortKey, isActive)
-      ].join(' ')}>
+      ].join(' ')}
+      role="button"
+      aria-label="Toggle column data">
       {children}
     </a>
-    <ul className="react-redux-composable-list-row-magic-header-custom-column-selector">
+    <ul className="react-redux-composable-list-row-magic-header-custom-column-selector"
+      role="menu">
       <li
         key="react-redux-composable-list-row-magic-header-custom-column-selector-heading"
-        className="react-redux-composable-list-row-magic-header-custom-column-selector-info">
+        className="react-redux-composable-list-row-magic-header-custom-column-selector-info"
+        aria-hidden={true}>
         <small>Toggle column data to:</small>
       </li>
-      {magicSorts.map(({ sortKey, sortFn, label }, key) =>
+      {magicSorts.map(({ sortKey, label }, key) =>
         <li key={key}>
           <a
             onClick={() => onSetMagic(sortKey)}
+            role="menuitemradio"
+            aria-checked={primarySort.sortKey === sortKey}
             className={getLinkClass(sortKey, isActive)}>
             {label}
           </a>

--- a/src/components/CellMagicHeader/style.less
+++ b/src/components/CellMagicHeader/style.less
@@ -34,13 +34,6 @@
 
   .react-redux-composable-list-row-magic-header-column-selector-sign {
     margin-left: 10px;
-
-    &:hover {
-      + .react-redux-composable-list-row-magic-header-custom-column-selector {
-          opacity: 1;
-          visibility: visible;
-      }
-    }
   }
 
   li.react-redux-composable-list-row-magic-header-custom-column-selector-info {
@@ -64,11 +57,6 @@
   border-radius: 0 0 3px 3px;
   transition: all .2s;
 
-  &:hover {
-    opacity: 1;
-    visibility: visible;
-  }
-
   li {
     margin: 0;
     cursor: pointer;
@@ -80,8 +68,7 @@
     }
 
     a:hover {
-      background: #4495d8;
-      color: #FFFFFF;
+      background: #EBEDEE;
     }
 
     &.react-redux-composable-list-row-magic-header-custom-column-selector-info {
@@ -89,4 +76,9 @@
       cursor: default;
     }
   }
+}
+
+.react-redux-composable-list-row-magic-header-custom-column-selector-shown {
+  opacity: 1;
+  visibility: visible;
 }

--- a/src/components/Enhanced/presenter.js
+++ b/src/components/Enhanced/presenter.js
@@ -22,6 +22,7 @@ class Enhanced extends Component {
       <div
         className={className || 'react-redux-composable-list'}
         style={style}
+        role="grid"
       >
         {children}
       </div>

--- a/src/components/HeaderCell/presenter.js
+++ b/src/components/HeaderCell/presenter.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import '../style.less';
 
+const isChildString = children => typeof children === 'string';
+
 const HeaderCell = ({
   style,
   className = '',
@@ -10,7 +12,7 @@ const HeaderCell = ({
   <div
     className={className || 'react-redux-composable-list-cell'}
     style={style}
-    role="columnheader"
+    role={isChildString(children) ? 'columnheader' : 'presentation'}
   >
     {children}
   </div>;

--- a/src/components/HeaderCell/presenter.js
+++ b/src/components/HeaderCell/presenter.js
@@ -10,6 +10,7 @@ const HeaderCell = ({
   <div
     className={className || 'react-redux-composable-list-cell'}
     style={style}
+    role="columnheader"
   >
     {children}
   </div>;

--- a/src/components/Row/presenter.js
+++ b/src/components/Row/presenter.js
@@ -52,7 +52,9 @@ const RowSelectable = ({
   return (
     <div
       onClick={handleClick}
-      className={rowClass.join(' ')}>
+      className={rowClass.join(' ')}
+      role="row"
+    >
       {children}
     </div>
   );
@@ -89,6 +91,7 @@ const RowNormal = ({
     <div
       className={classNameContainer.join(' ')}
       style={style}
+      role="row"
     >
       {children}
     </div>

--- a/src/components/Sort/presenter.js
+++ b/src/components/Sort/presenter.js
@@ -11,16 +11,16 @@ const Sort = ({ isActive, isReverse, onSort, suffix, children }) => {
   if (isActive) {
     linkClass.push('react-redux-composable-list-sort-active');
   }
-
   return (
-    <div role="presentation">
+    <div
+      role="columnheader"
+      aria-sort={sort.getAriaSort(isActive, isReverse)}>
       <a
         onClick={onSort}
         onKeyPress={sort.callIfActionKey(onSort)}
         className={linkClass.join(' ')}
         role="button"
-        tabIndex={0}
-        aria-sort={sort.getAriaSort(isActive, isReverse)}>
+        tabIndex={0}>
         { children }
         &nbsp;
         <SortCaret suffix={suffix} isActive={isActive} isReverse={isReverse} />

--- a/src/components/Sort/presenter.js
+++ b/src/components/Sort/presenter.js
@@ -4,6 +4,7 @@ import React from 'react';
 import './style.less';
 
 import SortCaret from '../../helper/components/SortCaret';
+import { sort } from '../../helper/services';
 
 const Sort = ({ isActive, isReverse, onSort, suffix, children }) => {
   const linkClass = ['react-redux-composable-list-sort'];
@@ -12,10 +13,12 @@ const Sort = ({ isActive, isReverse, onSort, suffix, children }) => {
   }
 
   return (
-    <div>
+    <div role="presentation">
       <a
         onClick={onSort}
-        className={linkClass.join(' ')}>
+        className={linkClass.join(' ')}
+        role="button"
+        aria-sort={sort.getAriaSort(isActive, isReverse)}>
         { children }
         &nbsp;
         <SortCaret suffix={suffix} isActive={isActive} isReverse={isReverse} />

--- a/src/components/Sort/presenter.js
+++ b/src/components/Sort/presenter.js
@@ -16,8 +16,10 @@ const Sort = ({ isActive, isReverse, onSort, suffix, children }) => {
     <div role="presentation">
       <a
         onClick={onSort}
+        onKeyPress={sort.callIfActionKey(onSort)}
         className={linkClass.join(' ')}
         role="button"
+        tabIndex={0}
         aria-sort={sort.getAriaSort(isActive, isReverse)}>
         { children }
         &nbsp;

--- a/src/helper/components/SortCaret/index.js
+++ b/src/helper/components/SortCaret/index.js
@@ -4,7 +4,7 @@ const takeSuffix = (suffix, isReverse) =>
   isReverse ? suffix['DESC'] : suffix['ASC'];
 
 const SortCaret = ({ suffix, isActive, isReverse }) =>
-  <span>
+  <span aria-hidden={true}>
     {(suffix && isActive)
       ? takeSuffix(suffix, isReverse)
       : null

--- a/src/helper/services/index.js
+++ b/src/helper/services/index.js
@@ -1,5 +1,7 @@
 import * as select from './select';
+import * as sort from './sort';
 
 export {
   select,
+  sort,
 };

--- a/src/helper/services/sort/index.js
+++ b/src/helper/services/sort/index.js
@@ -1,0 +1,6 @@
+export function getAriaSort(isActive, isReverse) {
+  if (!isActive) {
+    return 'none';
+  }
+  return isReverse ? 'descending' : 'ascending';
+}

--- a/src/helper/services/sort/index.js
+++ b/src/helper/services/sort/index.js
@@ -4,3 +4,8 @@ export function getAriaSort(isActive, isReverse) {
   }
   return isReverse ? 'descending' : 'ascending';
 }
+
+export const callIfActionKey = callbackFn => event => {
+  const isActionKey = event && ['Enter', ' '].indexOf(event.key) !== -1;
+  return isActionKey ? callbackFn(event) : null;
+};


### PR DESCRIPTION
…by adding proper roles and aria-attributes to the elements.

Also, the magic column menu is now toggled via *click* instead of hover. Otherwise it wouldn't be possible to navigate into it with screen readers.

### Resources:
- https://www.w3.org/TR/wai-aria-practices/examples/grid/dataGrids.html
- https://www.w3.org/TR/wai-aria-practices/examples/table/table.html
- https://dequeuniversity.com/library/aria/tables/sf-sortable-grid
- https://inclusive-components.design/menus-menu-buttons/