### PR TITLE
MagicHeader: Put sorting inside the dropdown

### DIFF
--- a/src/components/CellMagicHeader/container.js
+++ b/src/components/CellMagicHeader/container.js
@@ -9,14 +9,10 @@ import { actionCreators, selectors } from '../../ducks';
 import CellMagicHeader from './presenter';
 
 function mapStateToProps(state, { magicSorts, stateKey }) {
-  const { sortKey: stateSortKey, isReverse: stateIsReverse } = selectors.getSort(state, stateKey);
+  const { sortKey: stateSortKey, isReverse } = selectors.getSort(state, stateKey);
   const isActive = (sortKey) => sortKey === stateSortKey;
-
   const sortKey = selectors.getMagicSort(state, stateKey, magicSorts);
   const primarySort = find(magicSorts, (s) => s.sortKey === sortKey);
-
-  const isReverse = stateIsReverse && isActive(sortKey);
-
   return {
     magicSorts,
     primarySort,
@@ -27,9 +23,8 @@ function mapStateToProps(state, { magicSorts, stateKey }) {
 
 function mapDispatchToProps(dispatch, { stateKey }) {
   const { doTableSort, doSetMagicSort } = actionCreators;
-
   return bindActionCreators({
-    onSort: (sortKey, sortFn) => doTableSort(stateKey, sortKey, sortFn),
+    onSort: (sortKey, sortFn, isReverse) => doTableSort(stateKey, sortKey, sortFn, isReverse),
     onSetMagic: (sortKey) => doSetMagicSort(stateKey, sortKey),
   }, dispatch);
 }

--- a/src/components/CellMagicHeader/presenter.js
+++ b/src/components/CellMagicHeader/presenter.js
@@ -64,41 +64,63 @@ class CellMagicHeader extends Component {
           'react-redux-composable-list-row-magic-header'
         ].join(' ')}
         role="columnheader">
-        <a
+        <a className={[
+            'react-redux-composable-list-row-magic-header-column-selector',
+            getLinkClass(primarySort.sortKey, isActive)
+          ].join(' ')}
+          onClick={toggleColumnSelector}
+          onKeyPress={sort.callIfActionKey(toggleColumnSelector)}
+          aria-label={primarySort.label}
+          aria-haspopup="true"
+          aria-expanded={isColumnSelectorShown}
+          role="button"
+          tabIndex={0}>
+          {primarySort.label}
+          {children}
+          <SortCaret suffix={suffix} isActive={isActive(primarySort.sortKey)} isReverse={isReverse} />
+        </a>
+        <div className={[
+          'react-redux-composable-list-row-magic-header-custom-column-selector',
+            isColumnSelectorShown ? 'react-redux-composable-list-row-magic-header-custom-column-selector-shown' : '',
+          ].join(' ')}
+          ref={node => { this.columnSelectorNode = node; }}
+          role="menu">
+          <ul>
+          <li
+            key="react-redux-composable-list-row-magic-header-custom-column-sorting-info"
+            className="react-redux-composable-list-row-magic-header-custom-column-selector-info"
+            aria-hidden={true}>
+            <small>Sorting</small>
+          </li>
+          <li>
+          <a
           onClick={handleSortClick}
           onKeyPress={sort.callIfActionKey(handleSortClick)}
           className={getLinkClass(primarySort.sortKey, isActive)}
           role="button"
           tabIndex={0}
           aria-sort={sort.getAriaSort(isActive(primarySort.sortKey), isReverse)}>
-          {primarySort.label}
-          &nbsp;
-          <SortCaret suffix={suffix} isActive={isActive(primarySort.sortKey)} isReverse={isReverse} />
-        </a>
-        <a className={[
-            'react-redux-composable-list-row-magic-header-column-selector-sign',
-            getLinkClass(primarySort.sortKey, isActive)
-          ].join(' ')}
-          onClick={toggleColumnSelector}
-          onKeyPress={sort.callIfActionKey(toggleColumnSelector)}
-          aria-label="Toggle column data"
-          aria-haspopup="true"
-          aria-expanded={isColumnSelectorShown}
+          Ascending          
+          </a>
+          </li>
+          <li>
+          <a
+          onClick={handleSortClick}
+          onKeyPress={sort.callIfActionKey(handleSortClick)}
+          className={getLinkClass(primarySort.sortKey, isActive)}
           role="button"
-          tabIndex={0}>
-          {children}
-        </a>
-        <ul className={[
-          'react-redux-composable-list-row-magic-header-custom-column-selector',
-            isColumnSelectorShown ? 'react-redux-composable-list-row-magic-header-custom-column-selector-shown' : '',
-          ].join(' ')}
-          ref={node => { this.columnSelectorNode = node; }}
-          role="menu">
+          tabIndex={0}
+          aria-sort={sort.getAriaSort(isActive(primarySort.sortKey), isReverse)}>
+          Descending          
+          </a>
+          </li>
+          </ul>
+          <ul>
           <li
             key="react-redux-composable-list-row-magic-header-custom-column-selector-info"
             className="react-redux-composable-list-row-magic-header-custom-column-selector-info"
             aria-hidden={true}>
-            <small>Toggle column data to:</small>
+            <small>Toggle column to</small>
           </li>
           {magicSorts.map(({ sortKey, label }, key) =>
             <li key={key} role="presentation">
@@ -112,6 +134,7 @@ class CellMagicHeader extends Component {
             </li>
           )}
         </ul>
+        </div>
       </div>
     );
   }

--- a/src/components/CellMagicHeader/presenter.js
+++ b/src/components/CellMagicHeader/presenter.js
@@ -1,18 +1,14 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-
-import './style.less';
-
 import SortCaret from '../../helper/components/SortCaret';
 import { sort } from '../../helper/services';
+import './style.less';
 
 const getLinkClass = (sortKey, isActive) => {
   const linkClass = ['react-redux-composable-list-row-magic-header-inline'];
-
   if (isActive(sortKey)) {
     linkClass.push('react-redux-composable-list-row-magic-header-active');
   }
-
   return linkClass.join(' ');
 }
 
@@ -86,60 +82,59 @@ class CellMagicHeader extends Component {
           ref={node => { this.columnSelectorNode = node; }}
           role="menu">
           <ul>
-          <li
-            key="react-redux-composable-list-row-magic-header-custom-column-sorting-info"
-            className="react-redux-composable-list-row-magic-header-custom-column-selector-info"
-            aria-hidden={true}>
-            <small>Sorting</small>
-          </li>
-          <li>
-          <a
-          onClick={handleSortClick}
-          onKeyPress={sort.callIfActionKey(handleSortClick)}
-          className={getLinkClass(primarySort.sortKey, isActive)}
-          role="button"
-          tabIndex={0}
-          aria-sort={sort.getAriaSort(isActive(primarySort.sortKey), isReverse)}>
-          Ascending          
-          </a>
-          </li>
-          <li>
-          <a
-          onClick={handleSortClick}
-          onKeyPress={sort.callIfActionKey(handleSortClick)}
-          className={getLinkClass(primarySort.sortKey, isActive)}
-          role="button"
-          tabIndex={0}
-          aria-sort={sort.getAriaSort(isActive(primarySort.sortKey), isReverse)}>
-          Descending          
-          </a>
-          </li>
-          </ul>
-          <ul>
-          <li
-            key="react-redux-composable-list-row-magic-header-custom-column-selector-info"
-            className="react-redux-composable-list-row-magic-header-custom-column-selector-info"
-            aria-hidden={true}>
-            <small>Toggle column to</small>
-          </li>
-          {magicSorts.map(({ sortKey, label }, key) =>
-            <li key={key} role="presentation">
+            <li
+              key="react-redux-composable-list-row-magic-header-custom-column-sorting-info"
+              className="react-redux-composable-list-row-magic-header-custom-column-selector-info"
+              aria-hidden={true}>
+              <small>Sorting</small>
+            </li>
+            <li>
               <a
-                onClick={() => onSetMagic(sortKey)}
-                role="menuitemradio"
-                aria-checked={primarySort.sortKey === sortKey}
-                className={getLinkClass(sortKey, isActive)}>
-                {label}
+                onClick={handleSortClick}
+                onKeyPress={sort.callIfActionKey(handleSortClick)}
+                className={getLinkClass(primarySort.sortKey, isActive)}
+                role="button"
+                tabIndex={0}
+                aria-sort={sort.getAriaSort(isActive(primarySort.sortKey), isReverse)}>
+                Ascending
               </a>
             </li>
-          )}
-        </ul>
+            <li>
+              <a
+                onClick={handleSortClick}
+                onKeyPress={sort.callIfActionKey(handleSortClick)}
+                className={getLinkClass(primarySort.sortKey, isActive)}
+                role="button"
+                tabIndex={0}
+                aria-sort={sort.getAriaSort(isActive(primarySort.sortKey), isReverse)}>
+                Descending
+              </a>
+            </li>
+          </ul>
+          <ul>
+            <li
+              key="react-redux-composable-list-row-magic-header-custom-column-selector-info"
+              className="react-redux-composable-list-row-magic-header-custom-column-selector-info"
+              aria-hidden={true}>
+              <small>Toggle column to</small>
+            </li>
+            {magicSorts.map(({ sortKey, label }, key) =>
+              <li key={key} role="presentation">
+                <a
+                  onClick={() => onSetMagic(sortKey)}
+                  role="menuitemradio"
+                  aria-checked={primarySort.sortKey === sortKey}
+                  className={getLinkClass(sortKey, isActive)}>
+                  {label}
+                </a>
+              </li>
+            )}
+          </ul>
         </div>
       </div>
     );
   }
 }
-
 
 CellMagicHeader.propTypes = {
   primarySort: PropTypes.object.isRequired,

--- a/src/components/CellMagicHeader/style.less
+++ b/src/components/CellMagicHeader/style.less
@@ -24,19 +24,11 @@
 }
 
 .react-redux-composable-list-row-magic-header-active {
-  font-weight: 700;
+  font-weight: 600;
 }
 
 .react-redux-composable-list-row-magic-header-custom-column {
-  > div {
-    position: relative;
-  }
-
-  .react-redux-composable-list-row-magic-header-column-selector-sign {
-    margin-left: 10px;
-  }
-
-  li.react-redux-composable-list-row-magic-header-custom-column-selector-info {
+  .react-redux-composable-list-row-magic-header-custom-column-selector-info {
     color: #828282;
   }
 }
@@ -49,13 +41,22 @@
   left: -(10px);
   top: calc(100% - 5px);
   min-width: calc(100% + 10px);
-  margin: 12px 0 0 0;
+  margin: 10px 0 0 0;
   padding: 10px 0;
-  list-style-type: none;
   background: #FFFFFF;
   box-shadow: 0 1px 5px rgba(0, 0, 0, 0.3);
   border-radius: 0 0 3px 3px;
   transition: all .2s;
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+
+    + ul {
+      margin-top: 10px;
+    }
+  }
 
   li {
     margin: 0;
@@ -64,7 +65,7 @@
     a, &.react-redux-composable-list-row-magic-header-custom-column-selector-info {
       display: block;
       width: 100%;
-      padding: 10px 10px;
+      padding: 5px 10px;
     }
 
     a:hover {

--- a/src/components/Sort/container.js
+++ b/src/components/Sort/container.js
@@ -6,12 +6,9 @@ import { actionCreators, selectors } from '../../ducks';
 import Sort from './presenter';
 
 function mapStateToProps(state, { sortKey, stateKey }) {
-  const { sortKey: stateSortKey, isReverse: stateIsReverse } = selectors.getSort(state, stateKey);
-  const isActive = stateSortKey === sortKey;
-  const isReverse = stateIsReverse && isActive;
-
+  const { sortKey: stateSortKey, isReverse } = selectors.getSort(state, stateKey);
   return {
-    isActive,
+    isActive: sortKey === stateSortKey,
     isReverse,
   };
 }

--- a/src/components/Sort/presenter.js
+++ b/src/components/Sort/presenter.js
@@ -19,8 +19,7 @@ const Sort = ({ isActive, isReverse, onSort, suffix, children }) => {
         onClick={onSort}
         onKeyPress={sort.callIfActionKey(onSort)}
         className={linkClass.join(' ')}
-        role="button"
-        tabIndex={0}>
+        role="button">
         { children }
         &nbsp;
         <SortCaret suffix={suffix} isActive={isActive} isReverse={isReverse} />

--- a/src/components/SortSelected/container.js
+++ b/src/components/SortSelected/container.js
@@ -7,16 +7,13 @@ import { actionCreators, selectors } from '../../ducks';
 import Sort from '../Sort/presenter';
 
 const mapStateToProps = (state, { sortKey, stateKey }) => {
-  const { sortKey: stateSortKey, isReverse: stateIsReverse } = selectors.getSort(state, stateKey);
+  const { sortKey: stateSortKey, isReverse } = selectors.getSort(state, stateKey);
   const isActive = stateSortKey === sortKey;
-  const isReverse = stateIsReverse && isActive;
-
   const selection = selectors.getSelection(state, stateKey);
-
   return {
     isActive,
-    isReverse,
     selection,
+    isReverse,
   };
 };
 

--- a/src/ducks/sort/index.js
+++ b/src/ducks/sort/index.js
@@ -10,13 +10,14 @@ const TABLE_SORT = `${SLICE_NAME}/TABLE_SORT`;
 
 const INITIAL_STATE = {};
 
-function doTableSort(stateKey, sortKey, sortFn) {
+function doTableSort(stateKey, sortKey, sortFn, isReverse) {
   return {
     type: TABLE_SORT,
     payload: {
       stateKey,
       sortKey,
       sortFn,
+      isReverse,
     }
   };
 }
@@ -32,11 +33,11 @@ const reducer = (state = INITIAL_STATE, action) => {
 };
 
 function applyTableSort(state, action) {
-  const { stateKey, sortKey, sortFn } = action.payload;
-
-  const isReverse = !!state[stateKey] && state[stateKey].sortKey === sortKey && !state[stateKey].isReverse;
+  const { stateKey, sortKey, sortFn, isReverse: explicitReverse } = action.payload;
+  const isExplicitlyReverse = explicitReverse !== undefined;
+  const implicitReverse = !!state[stateKey] && state[stateKey].sortKey === sortKey && !state[stateKey].isReverse;
+  const isReverse = isExplicitlyReverse ? explicitReverse : implicitReverse;
   const enhancedSortFn = getEnhancedSortFn(isReverse, sortFn);
-
   return { ...state, [stateKey]: { sortFn: enhancedSortFn, sortKey, isReverse } };
 }
 

--- a/src/ducks/sort/spec.js
+++ b/src/ducks/sort/spec.js
@@ -48,6 +48,24 @@ describe('sort', () => {
       expect(beyondNextState[STATE_KEY].isReverse).to.eql(!isReverse);
     });
 
+    it('keeps the same sort when already set and explicitly providing the same value', () => {
+      const isReverse = true;
+      const newIsReverse = true;
+      const sortKey = 'name';
+      const sortFn = item => item.name;
+      const previousState = {};
+      const action = actionCreators.doTableSort(STATE_KEY, sortKey, sortFn, newIsReverse);
+
+      deepFreeze(action);
+      deepFreeze(previousState);
+
+      const nextState = reducers.tableSort(previousState, action);
+      const beyondNextState = reducers.tableSort(nextState, action);
+
+      expect(beyondNextState[STATE_KEY].sortKey).to.eql(sortKey);
+      expect(beyondNextState[STATE_KEY].isReverse).to.eql(isReverse);
+    });
+
     it('generates an enhanced sort fn', () => {
       const isReverse = false;
       const sortKey = 'name';


### PR DESCRIPTION
Putting the links to sort inside allows for the whole column header to be a link, instead of only the icon. This makes it easier for users to find, understand and use the magic column.
![image](https://user-images.githubusercontent.com/31034/57532871-c1e8c400-733c-11e9-8a87-60759fc7a84b.png)

**WIP! Still to-do:**
- The two sorting links have no direction, they both sort up or down if the user clicks twice
- When switching the magic column data, the selected option doesn't get highlighted until the user clicks a sorting