### PR TITLE
CellMagicHeader: Fix Immediately Closing Popover in React 17+

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Composable List in React and Redux",
   "main": "dist/bundle.js",
   "peerDependencies": {
-    "react": "^0.14.9 || ^15.3.0 || ^16.0.0",
+    "react": "^0.14.9 || ^15.3.0 || ^16.0.0 || ^17.0.0",
     "redux": "^3.0.0",
     "react-redux": "^4.0.0 || ^5.0.0"
   },

--- a/src/components/CellMagicHeader/presenter.js
+++ b/src/components/CellMagicHeader/presenter.js
@@ -29,8 +29,9 @@ class CellMagicHeader extends Component {
   };
 
   handleOutsideClick = (e) => {
+    const isClickOnButton = this.buttonNode && this.buttonNode.contains(e.target);
     const isClickInsideColumnSelector = this.columnSelectorNode && this.columnSelectorNode.contains(e.target);
-    if (!isClickInsideColumnSelector) {
+    if (!(isClickOnButton || isClickInsideColumnSelector)) {
       this.setColumnSelectorShown(false);
     }
   };
@@ -80,7 +81,8 @@ class CellMagicHeader extends Component {
           aria-label={primarySort.label}
           aria-haspopup="true"
           aria-expanded={isColumnSelectorShown}
-          role="button">
+          role="button"
+          ref={ref => { this.buttonNode = ref }}>
           {primarySort.label}
           {children}
           <SortCaret suffix={suffix} isActive={isActive(primarySort.sortKey)} isReverse={isReverse} />


### PR DESCRIPTION
React 17+ no longer attach event handlers at the document, but at the root node of the mount. This caused the outside click handler to be triggered by the same event that opened the popover, immediately closing it again.

Fixed by checking if the event target is contained in the opening button.